### PR TITLE
Update projekte.html

### DIFF
--- a/projekte.html
+++ b/projekte.html
@@ -75,9 +75,6 @@
           <div id="w-node-ab7b6b0e-6a4f-7494-06ea-3b019bb91065-faa2a0a4" data-w-id="ab7b6b0e-6a4f-7494-06ea-3b019bb91065" style="opacity:0" class="health-insurance-block"><img src="/images/Element-1dw.svg" height="60" width="173" alt="" class="_0margin">
             <h3 class="insurance-title">Meldepflicht. Einfach. Online.</h3>
             <p class="insurance-paragraph">„Digitales Wartezimmer“ war eine  Anlaufstelle für Bürger:innen, um ihre Daten im (potenziellen) COVID-19-Fall schnell und zuverlässig an das zuständige Gesundheitsamt übermitteln zu können. Damit wird die effiziente Kontaktpersonennachverfolgung sowie die Zuweisung von Corona-Tests unterstützt.</p>
-            <div class="read-more-link">
-              <a href="https://digitales-wartezimmer.org/de/" target="_blank">Mehr erfahren</a>
-            </div>
           </div>
           <div id="w-node-_4ca6bbab-8f11-2642-374a-a98c968c1c88-faa2a0a4" data-w-id="4ca6bbab-8f11-2642-374a-a98c968c1c88" style="opacity:0" class="health-insurance-block impftermin"><img src="/images/impfen.png" height="60" width="63" alt="" class="_0margin">
             <h3 class="insurance-title">Impfterminvermittlung</h3>


### PR DESCRIPTION
Entferne Link auf https://digitales-wartezimmer.org/de/ weil: a) Zertifikat abgelaufen
b) Seite ohne Inhalt