### PR TITLE
chore: remove dead whitelist config from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,15 +32,10 @@ url: "https://www.inoeg.de" # the base hostname & protocol for your site, e.g. h
 # override this via the `og_image` front-matter key.
 og_image_default: ""
 
-# Specify used plugins here and in the Gemfile to ensure full flexibility.
-# Note that github pages only supports plugins that are specified in _config.yml
+# Plugins. The site is built with `bundle exec jekyll build` in CI (not the
+# github-pages gem), so it is NOT restricted to the GitHub Pages plugin
+# allowlist — any Jekyll plugin listed here and in the Gemfile works.
 plugins:
-  - jekyll-feed
-  - jekyll-redirect-from
-  - jekyll-sitemap
-
-# List the same plugins again to  mimic GitHub Pages with --safe
-whitelist:
   - jekyll-feed
   - jekyll-redirect-from
   - jekyll-sitemap


### PR DESCRIPTION
Removes the `whitelist:` block from `_config.yml`.

The `whitelist` key only takes effect under `--safe` / the `github-pages` gem. This site builds with `bundle exec jekyll build` in CI (the `github-pages` gem is commented out in the Gemfile), so the whitelist was **inert** — and worse, it implied a plugin restriction that doesn't apply here. Also corrected the adjacent `plugins:` comment, which repeated the same inaccurate "github pages only supports plugins specified in _config.yml" claim.

**Verified** the whitelist was truly dead config: after removal, the build still emits all three plugins' output — `feed.xml`, `sitemap.xml`, and the `redirect-from` stub (`old-index.html`). Config parses, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)