### PR TITLE
chore: update postal address to Singerstr. 109, 10179 Berlin

### DIFF
--- a/_pages/datenschutz.html
+++ b/_pages/datenschutz.html
@@ -22,7 +22,7 @@ og_image: /assets/images/hero-inoeg_sw-p-500.png
       Die verwendeten Begriffe sind nicht geschlechtsspezifisch.
       <br>
       <br>
-      Stand: 22.06.2022
+      Stand: 23.08.2026
       <br>
       <br>
       <strong>Inhaltsübersicht</strong>
@@ -32,9 +32,9 @@ og_image: /assets/images/hero-inoeg_sw-p-500.png
       <br>
       Innovationsverbund Öffentliche Gesundheit e.V.
       <br>
-      Friedrichstr. 114a
+      Singerstr. 109
       <br>
-      10117 Berlin
+      10179 Berlin
       <br>
       ‍
       <br>

--- a/_pages/impressum.md
+++ b/_pages/impressum.md
@@ -14,8 +14,8 @@ Bianca Kastl (1. Vorsitzende)
 
 Tobias Opialla (2. Vorsitzender)
 
-Jan Sroka (Kassenwart) ‍ <br> <br> Kontakt: {{ site.email }} <br> <br> ‍Postanschrift: <br> Innovationsverbund Öffentliche Gesundheit e.V. <br> Friedrichstr.
-114a <br> 10117 Berlin <br> <br> Geltungsbereich:
+Jan Sroka (Kassenwart) ‍ <br> <br> Kontakt: {{ site.email }} <br> <br> ‍ Postanschrift: <br> Innovationsverbund Öffentliche Gesundheit e.V. <br> Singerstr. 109
+<br> 10179 Berlin <br> <br> Geltungsbereich:
 
 Das obenstehende Impressum gilt für diese Webseite sowie die nachfolgend genannten Social-Media-Präsenzen:
 


### PR DESCRIPTION
Der Verein ist umgezogen. Die Anschrift steht an zwei rechtlich relevanten Stellen, beide wurden aktualisiert:

- `_pages/impressum.md` — Postanschrift im Impressum
- `_pages/datenschutz.html` — Anschrift des Verantwortlichen im Sinne der DSGVO

Alt: Friedrichstr. 114a, 10117 Berlin → Neu: Singerstr. 109, 10179 Berlin

## Abweichung vom ursprünglichen Auftrag

Ursprünglich war nur das Impressum geändert. Die Datenschutzerklärung enthielt dieselbe Anschrift noch in der alten Fassung — ohne diese Änderung hätten die beiden Rechtstexte unterschiedliche Adressen genannt. Die Erweiterung auf `datenschutz.html` wurde vorab abgestimmt. Das "Stand"-Datum der Datenschutzerklärung wurde entsprechend auf den 23.08.2026 gesetzt.

## Verifikation

Lokal gegen den auf `main` rebasten Stand ausgeführt:

- `bundle exec jekyll build` — erfolgreich
- `npx prettier --check .` — sauber (mit prettier 3.9.6 aus den frisch gemergten Dependabot-Bumps)
- `npm run test-links` (html-proofer) — 28 interne Links, keine Fehler
- `grep` über `_pages/` und `_site/` — kein Vorkommen der alten Anschrift mehr