### PR TITLE
chore(deps): fix open Dependabot alerts (npm + rubygems)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.21.1)
+    json (2.21.2)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1821,9 +1821,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1957,9 +1957,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2589,9 +2589,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2609,7 +2609,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3292,9 +3292,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Behebt 10 der 11 offenen Dependabot-Alerts. **11 Alerts → 6 Pakete → 2 Befehle** (`npm update`, `bundle update --conservative`), aufgeteilt in einen Commit pro Ökosystem.

Alle betroffenen Pakete sind **transitive Dev-Abhängigkeiten** — sie landen nicht im ausgelieferten Site-Output, sondern nur im Build-/Test-Tooling (pa11y-ci, purgecss). Beide Änderungen sind reine Lockfile-Änderungen; `package.json` und `Gemfile` bleiben unverändert, weil die Constraints der Parent-Pakete die gepatchten Versionen bereits erlauben.

| Paket | Alerts | Severity | Version | Weg |
|---|---|---|---|---|
| `undici` | 3 | medium | 6.27.0 → 6.28.0 | pa11y-ci → cheerio |
| `ip-address` | 3 | high, medium | 10.2.0 → 10.5.0 | pa11y-ci → puppeteer → socks |
| `postcss` | 2 | high, medium | 8.5.16 → 8.5.26 | purgecss |
| `js-yaml` | 1 | high | 4.3.0 → 4.3.1 | pa11y-ci → cosmiconfig |
| `json` (gem) | 1 | low | 2.21.1 → 2.21.2 | transitiv, nicht im Gemfile |

## Nicht behebbar: `extract-zip` (high)

`GHSA-jmr9-qjv8-65gv` (unvalidated symlink path traversal) betrifft `<= 2.0.1` — das ist die **gesamte** Release-Historie, es gibt keine gepatchte Version. `first_patched_version` ist `null`, ein Versions-Bump kann den Alert also nicht schließen.

Einschätzung: geringes Risiko in diesem Repo. Der Pfad ist `pa11y-ci → puppeteer → @puppeteer/browsers → extract-zip`; entpackt wird ausschließlich der von Google signierte Chrome-Download während `npm ci`. Es werden keine nutzer- oder angreiferkontrollierten Archive verarbeitet. Vorschlag: als akzeptiertes Risiko dismissen (`tolerable_risk`), bis Upstream wechselt.

## Befund: automatische Security-Updates sind deaktiviert

`GET /repos/.../automated-security-fixes` meldet `{"enabled": false}`.

`.github/dependabot.yml` deckt bundler, npm und github-actions vollständig ab — das sind Version-Updates und die laufen wöchentlich. Sie bumpen aber nur direkte Abhängigkeiten, weshalb genau diese transitiven CVEs liegen blieben, bis sie hier manuell aufgeräumt wurden. Security-Updates sind der separate Mechanismus, der dafür zuständig wäre.

Empfehlung: in den Repo-Settings aktivieren (Settings → Code security → Dependabot security updates). Das ist eine Einstellung, keine Datei-Änderung, und daher nicht Teil dieses PRs.

## Verifikation

Lokal ausgeführt, alle grün:

- `bundle exec jekyll build` — erfolgreich
- `npm run purge-css` — erfolgreich
- `npm run test-links` (html-proofer) — 28 interne Links, keine Fehler
- `npx prettier --check .` — sauber

`npm run test-a11y` meldet `6/8 URLs passed`. **Vorbestehend, keine Regression**: ein frischer Clone von `main` ohne diese Änderungen liefert exakt dasselbe Ergebnis. Es sind die bekannten Webflow-Kontrastfehler, weshalb der Schritt in CI auf `continue-on-error` steht.