### PR TITLE
chore: convert Impressum address block from HTML to Markdown

### DIFF
--- a/_pages/impressum.md
+++ b/_pages/impressum.md
@@ -14,8 +14,16 @@ Bianca Kastl (1. Vorsitzende)
 
 Tobias Opialla (2. Vorsitzender)
 
-Jan Sroka (Kassenwart) ‍ <br> <br> Kontakt: {{ site.email }} <br> <br> ‍ Postanschrift: <br> Innovationsverbund Öffentliche Gesundheit e.V. <br> Singerstr. 109
-<br> 10179 Berlin <br> <br> Geltungsbereich:
+Jan Sroka (Kassenwart)
+
+Kontakt: {{ site.email }}
+
+Postanschrift:<br>
+Innovationsverbund Öffentliche Gesundheit e.V.<br>
+Singerstr. 109<br>
+10179 Berlin
+
+Geltungsbereich:
 
 Das obenstehende Impressum gilt für diese Webseite sowie die nachfolgend genannten Social-Media-Präsenzen:
 


### PR DESCRIPTION
`_pages/impressum.md` ist ein Webflow-Export, der in `.md` umbenannt, aber nie konvertiert wurde. Die Zeilen 11–15 nutzten bereits echte Markdown-Absätze, der Adressblock darunter dagegen `<br>`-Ketten für exakt dieselbe Aufgabe — ein Überbleibsel aus der alten HTML-Seite.

## Änderung

```diff
-Jan Sroka (Kassenwart) ‍ <br> <br> Kontakt: {{ site.email }} <br> <br> Postanschrift: <br> Innovationsverbund Öffentliche Gesundheit e.V. <br> Singerstr. 109
-<br> 10179 Berlin <br> <br> Geltungsbereich:
+Jan Sroka (Kassenwart)
+
+Kontakt: {{ site.email }}
+
+Postanschrift:<br>
+Innovationsverbund Öffentliche Gesundheit e.V.<br>
+Singerstr. 109<br>
+10179 Berlin
+
+Geltungsbereich:
```

`<br>` bleibt **nur innerhalb der Anschrift** stehen. Dort ist es nicht redundant: Markdown fasst einzelne Newlines zu Leerzeichen zusammen, die Straße stünde sonst hinter dem Vereinsnamen auf einer Zeile.

Zusätzlich entfernt: zwei Zero-Width-Joiner (U+200D), mit denen Webflow Abstände erzwungen hat. In Markdown sind sie wirkungslos und im Editor unsichtbar.

## Ergebnis im gerenderten HTML

Vorher ein einziger durchlaufender Absatz, jetzt semantisch getrennte `<p>`-Elemente:

```html
<p>Jan Sroka (Kassenwart)</p>
<p>Kontakt: kontakt@inoeg.de</p>
<p>Postanschrift:<br />
Innovationsverbund Öffentliche Gesundheit e.V.<br />
Singerstr. 109<br />
10179 Berlin</p>
<p>Geltungsbereich:</p>
```

## Verifikation

- **Sichtbarer Text unverändert**: das gerenderte HTML wurde gegen einen frischen Clone von `main` verglichen (Tags entfernt, Whitespace normalisiert) — Wortlaut identisch, nichts verloren oder hinzugekommen. Geändert hat sich ausschließlich die Absatzstruktur.
- `bundle exec jekyll build` — erfolgreich
- `npm run test-links` (html-proofer) — keine Fehler
- `npx prettier --check .` — sauber

Nur diese eine Datei ist betroffen. Die verbleibenden 25 Zero-Width-Joiner in `index.html` und `datenschutz.html` sind ein anderer Fall — dort stehen sie als `<br>‍<br>` und erzwingen eine Leerzeile. Ein Entfernen würde die Abstände sichtbar verändern und gehört daher nicht in diesen PR.