### PR TITLE
chore(format): set proseWrap to preserve for Markdown

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -42,7 +42,10 @@ overrides:
       - "*.md"
     options:
       parser: markdown
-      proseWrap: always
+      # preserve = Prettier lässt vorhandene Zeilenumbrüche in Fließtext in
+      # Ruhe, statt Absätze auf printWidth (160) neu umzubrechen. Listen,
+      # Tabellen und Code-Blöcke werden weiterhin formatiert.
+      proseWrap: preserve
   - files: "*.xml"
     options:
       bracketSameLine: true


### PR DESCRIPTION
Beim Speichern einer `.md`-Datei hat Prettier bisher den kompletten Absatz neu umgebrochen. Ursache ist `proseWrap: always` in `.prettierrc.yml`: damit werden Zeilenumbrüche im Fließtext ignoriert und Absätze stur auf `printWidth` (160 Zeichen) neu gesetzt.

Sichtbar wird das an willkürlichen Umbrüchen mitten im Satz — im Impressum etwa direkt vor der Hausnummer.

## Änderung

```diff
   - files:
       - "*.md"
     options:
       parser: markdown
-      proseWrap: always
+      proseWrap: preserve
```

`preserve` ist Prettiers eigener Standard: vorhandene Umbrüche bleiben so, wie sie getippt wurden. Listen, Tabellen und Code-Blöcke werden weiterhin formatiert — die Dateien bleiben also unter Prettier-Kontrolle, nur der Fließtext wird in Ruhe gelassen.

## Effekt

```
Eingabe (drei bewusst gesetzte Zeilen):
  Kurz eins.
  Kurz zwei.
  Kurz drei — ... 160 Zeichen.

always   → alles zu einem Absatz zusammengefasst, dann mitten im Satz neu umgebrochen
preserve → unverändert
```

## Verifikation

- `npx prettier --check .` — **sauber unmittelbar nach der Umstellung**. Keine einzige bestehende Datei muss neu formatiert werden, es entsteht also kein Reformatierungs-Rauschen und der CI-Schritt "Check formatting (Prettier)" bleibt grün.
- Verhalten gegen beide Einstellungen direkt gegeneinander geprüft (siehe oben).

Betrifft nur die Formatter-Konfiguration; keine Inhalts- oder Layout-Änderung an der Website.