### PR TITLE
fix(css): restore paragraph spacing on Markdown pages

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -41,3 +41,19 @@
 .text-end {
   text-align: end;
 }
+
+/* Absatzabstand im Fließtext-Bereich.
+
+   Der Webflow-Export setzt global `p { margin-bottom: 0 }`
+   (inog-website.webflow.css:216). Solange Absätze mit `<br> <br>` erzeugt
+   wurden, fiel das nicht auf. Seit Impressum & Co. echte `<p>`-Elemente aus
+   Markdown erzeugen, klebten die Absätze ohne Abstand aneinander.
+
+   Bewusst auf .content-box begrenzt: dieser Container existiert nur im
+   `default`-Layout, also genau auf den Markdown-Seiten (Impressum, Kontakt,
+   Veröffentlichungen, 404). Die Webflow-Seiten (Startseite, Projekte) nutzen
+   das `home`-Layout ohne .content-box und bleiben damit unberührt — eine
+   weiter gefasste Regel auf .block-content hat dort das Layout verschoben. */
+.content-box p {
+  margin-bottom: 1em;
+}


### PR DESCRIPTION
Nach dem Merge von #28 stehen die Absätze im Impressum ohne Leerzeile direkt untereinander.

## Ursache

Der Webflow-Export setzt global `p { margin-bottom: 0px }` — `assets/css/inog-website.webflow.css:216`. Diese Regel überschreibt das `margin-bottom: 10px` aus `webflow.css:233`, weil sie später in der Kaskade steht.

Solange die Absätze im Impressum mit `<br> <br>` **innerhalb eines einzigen** `<p>` erzeugt wurden, war das folgenlos: der Abstand kam von den `<br>`-Paaren, nicht von Absatz-Margins. Seit #28 echte `<p>`-Elemente aus Markdown entstehen, greift der Reset — gemessen ergab das einen Absatzabstand von 26px, also reine Zeilenhöhe ohne jeden Zwischenraum.

Das ist eine Regression aus #28, nicht ein vorbestehender Fehler.

## Fix

```css
.content-box p {
  margin-bottom: 1em;
}
```

In `custom.css`, nicht im generierten Webflow-Stylesheet — so bleibt der Export unangetastet, wie es der Kommentarkopf dieser Datei vorsieht.

**Scope auf `.content-box`**: dieser Container existiert nur im `default`-Layout, also genau auf den Markdown-Seiten. Die Startseite nutzt `home` ohne `.content-box` und bleibt unberührt.

## Verworfene erste Variante

Zuerst hatte ich `.block-content p` plus `p:last-child { margin-bottom: 0 }`. Das hat die **Startseite um 150px verkürzt**: dort sind sechs Absätze letzte Kinder ihres Containers, deren von Webflow gesetzten Abstand die `:last-child`-Regel entfernt hat. Im Headless-Browser aufgefallen, bevor es in einen PR ging.

## Verifikation

Seitenhöhen im Headless-Browser, jeweils gegen einen frischen Clone von `main`:

| Seite | main | mit Fix | |
|---|---|---|---|
| `/` | 5364 | 5364 | unverändert |
| `/impressum/` | 1063 | 1203 | +140 |
| `/veroeffentlichungen/` | 4909 | 5117 | +208 |
| `/kontakt/` | 907 | 983 | +76 |
| `/datenschutz/` | 7791 | 7807 | +16 |
| `/projekte/` | 3088 | 3120 | +32 |

Absatzabstand im Impressum jetzt 42px statt 26px.

`/projekte/` nutzt zwar `layout: home`, rendert aber eine `.content-box` (das home-Layout verschachtelt das default-Layout) — die +32px betreffen dort denselben Fließtext-Block und sind beabsichtigt.

Weiter geprüft:

- Regel überlebt PurgeCSS (`custom.css` unverändert bei 1854 Bytes)
- `npm run test-links` (html-proofer) — keine Fehler
- `npx prettier --check .` — sauber